### PR TITLE
fixes bug when attempting to login with un/pwd as a google-auth user

### DIFF
--- a/db/models/user.js
+++ b/db/models/user.js
@@ -13,6 +13,7 @@ let userSchema = new Schema({
 });
 
 userSchema.methods.comparePassword = function(pwd) {
+  if (!this.password) { return Promise.resolve(false); }
   return bcrypt.compare(pwd, this.password);
 };
 


### PR DESCRIPTION
bcrypt can't handle comparing to a null value, so we need to return
a promise that resolves to false if they don't have a password